### PR TITLE
Add sound support to skyboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Supported loaders:
 - Vanilla overworld/end skybox integration
 - Square textured, multi-textured, monocolor, and decoration skyboxes
 - Animated texture support with optional frame interpolation
+- Skybox sounds with fades, looping, and delays
 - Runtime API for mods to register and manage skyboxes
 - Multiloader architecture for Fabric and NeoForge
 

--- a/common/src/main/java/me/flashyreese/mods/nuit/NuitClient.java
+++ b/common/src/main/java/me/flashyreese/mods/nuit/NuitClient.java
@@ -2,6 +2,7 @@ package me.flashyreese.mods.nuit;
 
 import me.flashyreese.mods.nuit.config.NuitConfig;
 import me.flashyreese.mods.nuit.resource.SkyboxResourceListener;
+import net.minecraft.client.Minecraft;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -13,6 +14,13 @@ public class NuitClient {
 
     public static void init() {
         SkyboxManager.getInstance().setEnabled(config().generalSettings.enable);
+    }
+
+    public static void tick(Minecraft client) {
+        SkyboxManager.getInstance().updateLevel(client.level);
+        if (client.player != null) {
+            config().getKeyBinding().tick(client);
+        }
     }
 
     public static Logger getLogger() {

--- a/common/src/main/java/me/flashyreese/mods/nuit/SkyboxManager.java
+++ b/common/src/main/java/me/flashyreese/mods/nuit/SkyboxManager.java
@@ -49,6 +49,7 @@ public class SkyboxManager implements NuitApi {
     private CelestialController celestialController = null;
     private boolean celestialControllerConflict;
     private boolean enabled = true;
+    private ClientLevel currentLevel;
 
     public static Optional<Skybox> parseSkyboxJson(Identifier resourceLocation, JsonObject jsonObject) {
         Metadata metadata;
@@ -102,6 +103,7 @@ public class SkyboxManager implements NuitApi {
         this.registerTextures(skybox);
         Skybox previousSkybox = this.skyboxMap.put(resourceLocation, skybox);
         if (previousSkybox != null) {
+            previousSkybox.reset();
             this.activeSkyboxes.remove(previousSkybox);
             this.clearCurrentSkyboxIfRemoved(previousSkybox);
             this.releaseTextures(previousSkybox);
@@ -123,6 +125,7 @@ public class SkyboxManager implements NuitApi {
         this.registerTextures(skybox);
         Skybox previousSkybox = this.permanentSkyboxMap.put(resourceLocation, skybox);
         if (previousSkybox != null) {
+            previousSkybox.reset();
             this.activeSkyboxes.remove(previousSkybox);
             this.clearCurrentSkyboxIfRemoved(previousSkybox);
             this.releaseTextures(previousSkybox);
@@ -138,6 +141,7 @@ public class SkyboxManager implements NuitApi {
             return false;
         }
 
+        skybox.reset();
         this.activeSkyboxes.remove(skybox);
         this.clearCurrentSkyboxIfRemoved(skybox);
         this.releaseTextures(skybox);
@@ -153,6 +157,7 @@ public class SkyboxManager implements NuitApi {
             return false;
         }
 
+        skybox.reset();
         this.activeSkyboxes.remove(skybox);
         this.clearCurrentSkyboxIfRemoved(skybox);
         this.releaseTextures(skybox);
@@ -162,6 +167,7 @@ public class SkyboxManager implements NuitApi {
 
     @Internal
     public void clearSkyboxes() {
+        this.resetSkyboxes();
         DefaultHandler.clearConditionsExcept(this.permanentSkyboxMap.values());
         this.skyboxMap.values().forEach(this::releaseTextures);
         this.skyboxMap.clear();
@@ -222,7 +228,30 @@ public class SkyboxManager implements NuitApi {
     }
 
     public void setEnabled(boolean enabled) {
+        if (this.enabled && !enabled) {
+            this.resetSkyboxes();
+        }
         this.enabled = enabled;
+    }
+
+    /**
+     * Called even outside a world so audio cannot survive a disconnect or dimension change.
+     */
+    public void updateLevel(ClientLevel level) {
+        if (this.currentLevel != level) {
+            this.resetSkyboxes();
+            this.currentLevel = level;
+        }
+    }
+
+    private void resetSkyboxes() {
+        for (Skybox skybox : Iterables.concat(this.skyboxMap.values(), this.permanentSkyboxMap.values())) {
+            skybox.reset();
+        }
+        this.activeSkyboxes.clear();
+        this.currentSkybox = null;
+        this.celestialController = null;
+        this.celestialControllerConflict = false;
     }
 
     public Optional<Skybox> getCurrentSkybox() {
@@ -258,6 +287,10 @@ public class SkyboxManager implements NuitApi {
     }
 
     public void tick(ClientLevel level) {
+        this.updateLevel(level);
+        if (!this.enabled) {
+            return;
+        }
         for (Skybox skybox : Iterables.concat(this.skyboxMap.values(), this.permanentSkyboxMap.values())) {
             skybox.tick(level);
         }

--- a/common/src/main/java/me/flashyreese/mods/nuit/api/skyboxes/Skybox.java
+++ b/common/src/main/java/me/flashyreese/mods/nuit/api/skyboxes/Skybox.java
@@ -22,4 +22,11 @@ public interface Skybox {
      * @return whether this skybox should currently participate in rendering or skybox-dependent effects.
      */
     boolean isActive();
+
+    /**
+     * Stops transient effects when removed, reloaded, disabled, or changing levels.
+     * The instance may be ticked again afterwards, including permanent skyboxes.
+     */
+    default void reset() {
+    }
 }

--- a/common/src/main/java/me/flashyreese/mods/nuit/components/Properties.java
+++ b/common/src/main/java/me/flashyreese/mods/nuit/components/Properties.java
@@ -7,8 +7,11 @@ import me.flashyreese.mods.nuit.util.CodecUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Optional;
+
 public record Properties(int layer, ClockSource clock, Fade fade, int transitionInDuration, int transitionOutDuration, Fog fog,
-                         boolean renderSunSkyTint, boolean visibleUnderwater, Rotation rotation) {
+                         boolean renderSunSkyTint, boolean visibleUnderwater, Rotation rotation,
+                         Optional<SoundSettings> sound) {
     public static final Codec<Properties> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Codec.INT.optionalFieldOf("layer", 0).forGetter(Properties::layer),
             ClockSource.CODEC.optionalFieldOf("clock", ClockSource.defaultClock()).forGetter(Properties::clock),
@@ -18,8 +21,14 @@ public record Properties(int layer, ClockSource clock, Fade fade, int transition
             Fog.CODEC.optionalFieldOf("fog", Fog.of()).forGetter(Properties::fog),
             Codec.BOOL.optionalFieldOf("sunSkyTint", true).forGetter(Properties::renderSunSkyTint),
             Codec.BOOL.optionalFieldOf("visibleUnderwater", true).forGetter(Properties::visibleUnderwater),
-            Rotation.CODEC.optionalFieldOf("rotation", Rotation.of()).forGetter(Properties::rotation)
+            Rotation.CODEC.optionalFieldOf("rotation", Rotation.of()).forGetter(Properties::rotation),
+            SoundSettings.CODEC.optionalFieldOf("sound").forGetter(Properties::sound)
     ).apply(instance, Properties::new));
+
+    public Properties(int layer, ClockSource clock, Fade fade, int transitionInDuration, int transitionOutDuration, Fog fog,
+                      boolean renderSunSkyTint, boolean visibleUnderwater, Rotation rotation) {
+        this(layer, clock, fade, transitionInDuration, transitionOutDuration, fog, renderSunSkyTint, visibleUnderwater, rotation, Optional.empty());
+    }
 
     public Properties(int layer, Fade fade, int transitionInDuration, int transitionOutDuration, Fog fog,
                       boolean renderSunSkyTint, boolean visibleUnderwater, Rotation rotation) {

--- a/common/src/main/java/me/flashyreese/mods/nuit/components/SoundSettings.java
+++ b/common/src/main/java/me/flashyreese/mods/nuit/components/SoundSettings.java
@@ -1,0 +1,35 @@
+package me.flashyreese.mods.nuit.components;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.resources.Identifier;
+
+public record SoundSettings(Identifier file, boolean clipToFade, boolean loop, int delay) {
+    public static final Codec<SoundSettings> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            Identifier.CODEC.validate(SoundSettings::validateFile).fieldOf("file").forGetter(SoundSettings::file),
+            Codec.BOOL.optionalFieldOf("clipToFade", true).forGetter(SoundSettings::clipToFade),
+            Codec.BOOL.optionalFieldOf("loop", false).forGetter(SoundSettings::loop),
+            Codec.intRange(0, Integer.MAX_VALUE).optionalFieldOf("delay", 0).forGetter(SoundSettings::delay)
+    ).apply(instance, SoundSettings::new));
+
+    public SoundSettings {
+        validateFile(file).getOrThrow();
+        if (delay < 0) {
+            throw new IllegalArgumentException("Sound delay must be nonnegative");
+        }
+    }
+
+    public SoundSettings(Identifier file) {
+        this(file, true, false, 0);
+    }
+
+    private static DataResult<Identifier> validateFile(Identifier file) {
+        if (file != null && file.getPath().startsWith("sounds/") && file.getPath().endsWith(".ogg") &&
+                file.getPath().length() > "sounds/.ogg".length()) {
+            return DataResult.success(file);
+        } else {
+            return DataResult.error(() -> "Sound file must be a namespaced sounds/*.ogg resource: " + file);
+        }
+    }
+}

--- a/common/src/main/java/me/flashyreese/mods/nuit/skybox/AbstractSkybox.java
+++ b/common/src/main/java/me/flashyreese/mods/nuit/skybox/AbstractSkybox.java
@@ -5,14 +5,16 @@ import me.flashyreese.mods.nuit.NuitClient;
 import me.flashyreese.mods.nuit.api.skyboxes.NuitSkybox;
 import me.flashyreese.mods.nuit.components.Conditions;
 import me.flashyreese.mods.nuit.components.Properties;
+import me.flashyreese.mods.nuit.components.SoundSettings;
 import me.flashyreese.mods.nuit.components.Weather;
+import me.flashyreese.mods.nuit.sound.MinecraftSoundBackend;
+import me.flashyreese.mods.nuit.sound.SoundPlayback;
 import me.flashyreese.mods.nuit.util.Utils;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.registries.Registries;
-import net.minecraft.resources.Identifier;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.biome.Biome;
@@ -40,6 +42,12 @@ public abstract class AbstractSkybox implements NuitSkybox {
     protected Properties properties = Properties.of();
     protected Conditions conditions = Conditions.of();
     protected float conditionAlpha = 0f;
+    protected boolean conditionsMet;
+    protected float soundVolume;
+    protected boolean soundFadeActive;
+    private SoundPlayback soundPlayback;
+    private long soundFadeTime;
+    private long lastSoundFadeTime = -1;
 
     protected AbstractSkybox() {
     }
@@ -52,6 +60,48 @@ public abstract class AbstractSkybox implements NuitSkybox {
     @Override
     public void tick(ClientLevel level) {
         this.updateAlpha(level);
+        if (this.properties.sound().isEmpty()) {
+            if (this.soundPlayback != null) {
+                this.soundPlayback.reset();
+                this.soundPlayback = null;
+            }
+            return;
+        }
+
+        SoundSettings soundSettings = this.properties.sound().orElseThrow();
+        if (this.soundPlayback == null) {
+            this.soundPlayback = this.createSoundPlayback(soundSettings);
+        }
+
+        // Let a playing sound fade out when conditions fail, but do not start a new sound.
+        boolean playSound = this.soundFadeActive && (this.conditionsMet || this.soundPlayback.isActive());
+        int delay = this.properties.fade().keyFrames().isEmpty() ? soundSettings.delay() : 0;
+
+        // A zero-volume keyframe can end one fade and start the next. Restart once when reaching it.
+        if (playSound && this.soundFadeTime != this.lastSoundFadeTime && this.soundVolume == 0.0F &&
+                this.isFadeInStart(this.soundFadeTime)) {
+            this.soundPlayback.tick(false, 0.0F, 0);
+        }
+        this.lastSoundFadeTime = this.soundFadeTime;
+        this.soundPlayback.tick(playSound, this.soundVolume, delay);
+    }
+
+    protected SoundPlayback createSoundPlayback(SoundSettings settings) {
+        return new SoundPlayback(settings, new MinecraftSoundBackend());
+    }
+
+    @Override
+    public void reset() {
+        if (this.soundPlayback != null) {
+            this.soundPlayback.reset();
+            this.soundPlayback = null;
+        }
+        this.alpha = 0.0F;
+        this.conditionAlpha = 0.0F;
+        this.conditionsMet = false;
+        this.soundVolume = 0.0F;
+        this.soundFadeActive = false;
+        this.lastSoundFadeTime = -1;
     }
 
     /**
@@ -59,40 +109,65 @@ public abstract class AbstractSkybox implements NuitSkybox {
      */
     @Override
     public void updateAlpha(ClientLevel level) {
-        long currentTime = this.properties.clock().getCycleTicks(level, this.properties.fade().duration());
-        boolean condition = this.checkConditions();
-        float fadeAlpha = 1f;
-        if (this.properties.fade().keyFrames().isEmpty()) {
-            this.conditionAlpha = Utils.calculateConditionAlphaValue(1f, 0f, this.conditionAlpha, condition ? this.properties.transitionInDuration() : this.properties.transitionOutDuration(), condition);
-        } else {
-            if (this.properties.fade().duration() <= NuitClient.config().generalSettings.fadeCacheDuration) {
-                fadeAlpha = this.cachedKeyFrames.computeIfAbsent(currentTime, time -> {
-                    Utils.KeyframePair keyFrames = Utils.findClosestKeyframes(this.properties.fade().keyFrames(), time).orElseThrow();
-                    return Utils.calculateInterpolatedAlpha(
-                            time,
-                            this.properties.fade().duration(),
-                            keyFrames.current(),
-                            keyFrames.next(),
-                            this.properties.fade().keyFrames().get(keyFrames.current()),
-                            this.properties.fade().keyFrames().get(keyFrames.next())
-                    );
-                });
-            } else {
-                Utils.KeyframePair keyFrames = Utils.findClosestKeyframes(this.properties.fade().keyFrames(), currentTime).orElseThrow();
-                fadeAlpha = Utils.calculateInterpolatedAlpha(
-                        currentTime,
-                        this.properties.fade().duration(),
-                        keyFrames.current(),
-                        keyFrames.next(),
-                        this.properties.fade().keyFrames().get(keyFrames.current()),
-                        this.properties.fade().keyFrames().get(keyFrames.next())
-                );
-            }
-
-            this.conditionAlpha = Utils.calculateConditionAlphaValue(1f, 0f, this.conditionAlpha, condition ? this.properties.transitionInDuration() : this.properties.transitionOutDuration(), condition);
+        long currentTime = this.getFadeTime(level);
+        this.conditionsMet = this.checkConditions();
+        this.conditionAlpha = Utils.calculateConditionAlphaValue(
+                1f,
+                0f,
+                this.conditionAlpha,
+                this.conditionsMet ? this.properties.transitionInDuration() : this.properties.transitionOutDuration(),
+                this.conditionsMet
+        );
+        this.alpha = this.getFadeAlpha(currentTime) * this.conditionAlpha;
+        this.soundVolume = 0.0F;
+        this.soundFadeActive = false;
+        if (this.properties.sound().isPresent()) {
+            int delay = this.properties.sound().orElseThrow().delay();
+            long duration = this.properties.fade().duration();
+            this.soundFadeTime = Math.floorMod(currentTime - delay % duration, duration);
+            this.soundVolume = this.getFadeAlpha(this.soundFadeTime) * this.conditionAlpha;
+            this.soundFadeActive = this.soundVolume > 0.0F || (this.conditionsMet && this.isFadeInStart(this.soundFadeTime));
         }
+    }
 
-        this.alpha = fadeAlpha * this.conditionAlpha;
+    protected long getFadeTime(ClientLevel level) {
+        return this.properties.clock().getCycleTicks(level, this.properties.fade().duration());
+    }
+
+    protected float getFadeAlpha(long currentTime) {
+        if (this.properties.fade().keyFrames().isEmpty()) {
+            return 1.0F;
+        }
+        if (this.properties.fade().duration() <= NuitClient.config().generalSettings.fadeCacheDuration) {
+            return this.cachedKeyFrames.computeIfAbsent(currentTime, this::calculateFadeAlpha);
+        } else {
+            return this.calculateFadeAlpha(currentTime);
+        }
+    }
+
+    protected float calculateFadeAlpha(long currentTime) {
+        if (this.properties.fade().keyFrames().isEmpty()) {
+            return 1.0F;
+        }
+        Utils.KeyframePair keyFrames = Utils.findClosestKeyframes(this.properties.fade().keyFrames(), currentTime).orElseThrow();
+        return Utils.calculateInterpolatedAlpha(
+                currentTime,
+                this.properties.fade().duration(),
+                keyFrames.current(),
+                keyFrames.next(),
+                this.properties.fade().keyFrames().get(keyFrames.current()),
+                this.properties.fade().keyFrames().get(keyFrames.next())
+        );
+    }
+
+    private boolean isFadeInStart(long currentTime) {
+        Map<Long, Float> keyFrames = this.properties.fade().keyFrames();
+        Float fadeAlpha = keyFrames.get(currentTime);
+        if (fadeAlpha == null || fadeAlpha != 0.0F) {
+            return false;
+        }
+        Utils.KeyframePair keyframePair = Utils.findClosestKeyframes(keyFrames, currentTime).orElseThrow();
+        return keyFrames.get(keyframePair.next()) > 0.0F;
     }
 
     /**

--- a/common/src/main/java/me/flashyreese/mods/nuit/sound/MinecraftSoundBackend.java
+++ b/common/src/main/java/me/flashyreese/mods/nuit/sound/MinecraftSoundBackend.java
@@ -1,0 +1,68 @@
+package me.flashyreese.mods.nuit.sound;
+
+import me.flashyreese.mods.nuit.NuitClient;
+import me.flashyreese.mods.nuit.components.SoundSettings;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.sounds.SoundEngine;
+
+/**
+ * Uses Minecraft's sound engine for resource loading, streaming, device management and pausing.
+ */
+public final class MinecraftSoundBackend implements SoundPlayback.Backend {
+    private ResourceSoundInstance soundInstance;
+    private boolean missingResource;
+
+    @Override
+    public boolean play(SoundSettings settings, float volume) {
+        if (this.isActive()) {
+            this.setVolume(volume);
+            return true;
+        }
+        if (this.missingResource) {
+            return false;
+        }
+
+        Minecraft client = Minecraft.getInstance();
+        if (client.getResourceManager().getResource(settings.file()).isEmpty()) {
+            this.missingResource = true;
+            NuitClient.getLogger().warn("Cannot play Nuit sound: resource {} was not found", settings.file());
+            return false;
+        }
+
+        this.stop();
+        ResourceSoundInstance sound = new ResourceSoundInstance(settings, volume);
+        if (client.getSoundManager().play(sound) == SoundEngine.PlayResult.NOT_STARTED) {
+            sound.stopPlayback();
+            return false;
+        }
+        this.soundInstance = sound;
+        return true;
+    }
+
+    @Override
+    public void setVolume(float volume) {
+        if (this.soundInstance != null) {
+            this.soundInstance.setVolume(volume);
+        }
+    }
+
+    @Override
+    public boolean isActive() {
+        return this.soundInstance != null && !this.soundInstance.isStopped() && Minecraft.getInstance().getSoundManager().isActive(this.soundInstance);
+    }
+
+    @Override
+    public void stop() {
+        if (this.soundInstance != null) {
+            this.soundInstance.stopPlayback();
+            Minecraft.getInstance().getSoundManager().stop(this.soundInstance);
+            this.soundInstance = null;
+        }
+    }
+
+    @Override
+    public void reset() {
+        this.stop();
+        this.missingResource = false;
+    }
+}

--- a/common/src/main/java/me/flashyreese/mods/nuit/sound/ResourceSoundInstance.java
+++ b/common/src/main/java/me/flashyreese/mods/nuit/sound/ResourceSoundInstance.java
@@ -1,0 +1,75 @@
+package me.flashyreese.mods.nuit.sound;
+
+import me.flashyreese.mods.nuit.components.SoundSettings;
+import net.minecraft.client.resources.sounds.AbstractSoundInstance;
+import net.minecraft.client.resources.sounds.Sound;
+import net.minecraft.client.resources.sounds.SoundInstance;
+import net.minecraft.client.resources.sounds.TickableSoundInstance;
+import net.minecraft.client.sounds.SoundManager;
+import net.minecraft.client.sounds.WeighedSoundEvents;
+import net.minecraft.resources.Identifier;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.valueproviders.ConstantFloat;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * A non-positional Ogg resource using Minecraft's Ambient/Environment volume control.
+ */
+public final class ResourceSoundInstance extends AbstractSoundInstance implements TickableSoundInstance {
+    private final WeighedSoundEvents event;
+    private boolean stopped;
+
+    public ResourceSoundInstance(Identifier file) {
+        this(new SoundSettings(file), 1.0F);
+    }
+
+    public ResourceSoundInstance(SoundSettings settings, float volume) {
+        super(settings.file(), SoundSource.AMBIENT, SoundInstance.createUnseededRandom());
+        this.setVolume(volume);
+        this.pitch = 1.0F;
+        this.looping = settings.loop();
+        this.delay = 0;
+        this.relative = true;
+        this.attenuation = Attenuation.NONE;
+        this.sound = new Sound(
+                Sound.SOUND_LISTER.fileToId(settings.file()),
+                ConstantFloat.of(1.0F),
+                ConstantFloat.of(1.0F),
+                1,
+                Sound.Type.FILE,
+                true,
+                false,
+                16
+        );
+        this.event = new WeighedSoundEvents(this.identifier, null);
+        this.event.addSound(this.sound);
+    }
+
+    @Override
+    public WeighedSoundEvents resolve(@NonNull SoundManager soundManager) {
+        return this.event;
+    }
+
+    public void setVolume(float volume) {
+        this.volume = Float.isFinite(volume) ? Math.clamp(volume, 0.0F, 1.0F) : 0.0F;
+    }
+
+    @Override
+    public void tick() {
+    }
+
+    @Override
+    public boolean canStartSilent() {
+        return true;
+    }
+
+    @Override
+    public boolean isStopped() {
+        return this.stopped;
+    }
+
+    public void stopPlayback() {
+        this.stopped = true;
+        this.looping = false;
+    }
+}

--- a/common/src/main/java/me/flashyreese/mods/nuit/sound/SoundPlayback.java
+++ b/common/src/main/java/me/flashyreese/mods/nuit/sound/SoundPlayback.java
@@ -1,0 +1,121 @@
+package me.flashyreese.mods.nuit.sound;
+
+import me.flashyreese.mods.nuit.components.SoundSettings;
+
+import java.util.Objects;
+
+/**
+ * Controls one sound instance independently of Minecraft's audio device. Tick once per client world tick.
+ */
+public final class SoundPlayback {
+    private static final int RETRY_INTERVAL_TICKS = 20;
+
+    private final SoundSettings settings;
+    private final Backend backend;
+    private boolean enabled;
+    private boolean triggered;
+    private int delayRemaining;
+    private int retryRemaining;
+
+    public SoundPlayback(SoundSettings settings, Backend backend) {
+        this.settings = Objects.requireNonNull(settings);
+        this.backend = Objects.requireNonNull(backend);
+    }
+
+    /**
+     * Playback is enabled by the skybox's fade and conditions. The caller applies the delay to fade
+     * keyframes; without keyframes, startDelayTicks delays playback after it becomes enabled.
+     * A fade-in may start at zero volume. An unclipped, non-looping sound may finish after playback
+     * is disabled.
+     */
+    public void tick(boolean enabled, float fadeVolume, int startDelayTicks) {
+        float volume = this.settings.clipToFade() ? clampVolume(fadeVolume) : 1.0F;
+        this.backend.setVolume(volume);
+
+        if (!enabled) {
+            this.clearActivation();
+            if (this.settings.loop() || this.settings.clipToFade()) {
+                this.backend.stop();
+            }
+            return;
+        }
+
+        if (!this.enabled) {
+            this.enabled = true;
+            this.triggered = false;
+            this.delayRemaining = Math.max(0, startDelayTicks);
+        }
+        if (this.retryRemaining > 0) {
+            this.retryRemaining--;
+        }
+        boolean waitingForDelay = this.delayRemaining > 0;
+        if (waitingForDelay) {
+            this.delayRemaining--;
+        }
+
+        if (this.backend.isActive()) {
+            // An unclipped sound may still be playing. Let it finish before starting another instance.
+            this.triggered = true;
+            return;
+        }
+        if (this.triggered && !this.settings.loop()) {
+            return;
+        }
+        if (waitingForDelay || this.retryRemaining > 0) {
+            return;
+        }
+
+        // Try non-looping sounds once, even if playback fails. Looping sounds can retry later.
+        this.triggered = true;
+        this.retryRemaining = RETRY_INTERVAL_TICKS;
+        this.backend.play(this.settings, volume);
+    }
+
+    /**
+     * Stops the sound, including unclipped playback, and cancels any pending delay.
+     */
+    public void stop() {
+        this.backend.stop();
+        this.clearActivation();
+    }
+
+    /**
+     * Also clears resource failure state, allowing playback to retry after a resource reload.
+     */
+    public void reset() {
+        this.backend.reset();
+        this.clearActivation();
+    }
+
+    public boolean isActive() {
+        return this.backend.isActive();
+    }
+
+    private void clearActivation() {
+        this.enabled = false;
+        this.triggered = false;
+        this.delayRemaining = 0;
+        this.retryRemaining = 0;
+    }
+
+    private static float clampVolume(float fadeVolume) {
+        return Float.isFinite(fadeVolume) ? Math.clamp(fadeVolume, 0.0F, 1.0F) : 0.0F;
+    }
+
+    /**
+     * A backend owns at most one sound instance. Volume excludes Minecraft's category and master sliders.
+     */
+    public interface Backend {
+        boolean play(SoundSettings settings, float volume);
+
+        void setVolume(float volume);
+
+        boolean isActive();
+
+        void stop();
+
+        default void reset() {
+            this.stop();
+        }
+    }
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -74,10 +74,13 @@ public interface Skybox {
     default int getLayer() { return 0; }
     void tick(ClientLevel level);
     boolean isActive();
+    default void reset() { }
 }
 ```
 
-Lower layers render first.
+Lower layers render first. Override `reset()` to stop transient effects and clear activation state when a skybox is
+removed, resources reload, Nuit is disabled, or the client disconnects or changes levels. The instance may be ticked
+again after reset, including permanent skyboxes, so it must remain reusable.
 
 ### `RenderableSkybox`
 
@@ -102,7 +105,14 @@ public interface NuitSkybox extends RenderableSkybox {
 }
 ```
 
-`AbstractSkybox` already implements the standard Nuit alpha and condition behavior.
+`AbstractSkybox` implements the standard Nuit alpha and condition behavior, plus optional attached sound playback.
+Access settings through `getProperties().sound()`, which returns `Optional<SoundSettings>`. Audio settings belong to the
+shared `Properties` record and its codec, so skybox types do not need separate sound fields or constructor parameters.
+See the [sound schema](schema.md#sound) for the `properties.sound` resource format.
+
+Custom subclasses overriding `tick(ClientLevel)` or `reset()` must call the corresponding superclass method to update
+and clean up attached sounds. `AbstractSkybox.reset()` also clears alpha and condition transition state, allowing a
+fresh activation when the instance is ticked again.
 
 ### `SkyboxTextureProvider`
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -25,13 +25,13 @@ Each JSON file defines one skybox layer.
 
 ## Shared Fields
 
-All skybox types share these metadata and optional objects.
+All built-in skybox types share these metadata and optional objects.
 
 | Field | Type | Required | Default | Notes |
 |-------|------|----------|---------|-------|
 | `schemaVersion` | integer | yes | none | Current value is `1`. |
 | `type` | identifier/string | yes | none | Built-in types may omit the `nuit:` namespace. |
-| `properties` | object | no | default properties | Render order, fade, fog, rotation, transitions. |
+| `properties` | object | no | default properties | Render order, fade, fog, rotation, transitions, and optional sound. |
 | `conditions` | object | no | no restrictions | Biome, dimension, skybox, weather, effect, and coordinate checks. |
 
 ## Built-In Types
@@ -93,6 +93,9 @@ Nuit skybox shaders are normal client resources. Resource packs can override the
     "axis": {
       "0": [0.0, 1.0, 0.0]
     }
+  },
+  "sound": {
+    "file": "example:sounds/sky/chime.ogg"
   }
 }
 ```
@@ -108,6 +111,7 @@ Nuit skybox shaders are normal client resources. Resource packs can override the
 | `sunSkyTint` | boolean | `true` | If `false`, disables vanilla sunrise/sunset tint contribution for this skybox while rendering. |
 | `visibleUnderwater` | boolean | `true` | If `false`, the skybox is hidden underwater. |
 | `rotation` | object | no static mapping/axis rotation, `duration: 24000`, `speed: 1.0` | Skybox rotation. |
+| `sound` | object | no sound | Ogg audio with optional fading, looping, and delay. |
 
 ### `clock`
 
@@ -179,6 +183,70 @@ If several such sun decorations are active, they must use the same `clock` and `
 keeps the dimension's normal sunrise and fog direction and logs a warning.
 
 Moon-only and stars-only decorations do not affect sunrise colors or fog direction.
+
+### `sound`
+
+Add `sound` inside `properties` to play a sound alongside your skybox. All built-in skybox types support it:
+
+```json
+{
+  "file": "example:sounds/sky/chime.ogg",
+  "clipToFade": true,
+  "loop": false,
+  "delay": 0
+}
+```
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `file` | identifier | required | Sound file to play, including the `sounds/` folder and `.ogg` extension. |
+| `clipToFade` | boolean | `true` | Fade the sound in and out using the skybox's fade settings. Set to `false` to ignore volume fades. |
+| `loop` | boolean | `false` | Repeat the sound while the fade settings and conditions allow it to play. |
+| `delay` | integer >= 0 | `0` | How many ticks later the sound plays. See below for how this works with fade keyframes. |
+
+For this example, put your sound at `assets/example/sounds/sky/chime.ogg` in your resource pack. You do not need
+to add it to `sounds.json`.
+
+Use an `.ogg` file saved as **Ogg Vorbis**, like Minecraft's own sounds. If your sound is an MP3, WAV, FLAC, or Opus
+file, convert it to Ogg Vorbis first. Changing the filename to end in `.ogg` is not enough.
+
+#### Playback and fades
+
+Sound follows the skybox's `conditions`, `properties.fade`, and `properties.clock`. For example, you can use biome
+conditions for forest ambience, weather conditions for rain sounds, or height conditions for cave sounds.
+
+With `clipToFade: true`, fade keyframe values also control sound volume: `0.0` is silent and `1.0` is full volume.
+The sound starts silently at the keyframe where a fade-in begins and stops when the fade-out reaches zero.
+`transitionInDuration` and `transitionOutDuration` also fade the volume when conditions change, such as when the
+player enters or leaves an allowed biome. New sounds only start while the conditions are met.
+
+With `clipToFade: false`, the sound starts at the same time but plays at normal volume. If `loop` is `false`, it
+finishes the whole file even if the skybox fades away or the player leaves an allowed biome. If `loop` is `true`,
+it repeats at normal volume until the fade-out ends, then stops without fading the sound itself.
+
+With `loop: false`, the sound plays once each time its fade or conditions become active. Finishing the file early
+does not start it again. With `loop: true`, the sound repeats until it should stop. Each skybox plays only one copy
+of its sound at a time, so a sound still finishing does not overlap with another copy.
+
+If the player joins or enters an allowed biome partway through a fade, the sound starts from the beginning of the
+file. Players can adjust skybox sound volume with **Ambient/Environment** and **Master Volume** in **Music & Sounds**.
+
+#### Delay and clocks
+
+With fade keyframes, `delay` moves all sound fades later by that many ticks using the selected `clock`. For example,
+`delay: 20` moves a sound that would play from ticks 0 through 100 to ticks 20 through 120. The skybox still appears
+at its original time. Delayed sound fades that pass the end of `fade.duration` continue into the next cycle.
+
+Without fade keyframes, `delay` makes the sound wait after the conditions are met. For example, with `delay: 40`
+and a biome condition, the sound starts two seconds after entering that biome at normal tick speed. Leaving before
+the wait ends cancels the sound. Entering again starts the wait over, even if the skybox was still fading out.
+
+A fixed or paused `clock` holds the sound's fade at its current volume. It does not pause the sound file, skip ahead
+in it, or change how fast it plays.
+
+Disabling Nuit, removing the skybox, reloading resources with F3+T, leaving the world, or changing dimensions stops
+all skybox sounds, including sounds with `clipToFade: false`. They can play again when their fade and conditions
+allow it.
 
 ## `conditions`
 

--- a/fabric/src/main/java/me/flashyreese/mods/nuit/fabric/NuitClientFabric.java
+++ b/fabric/src/main/java/me/flashyreese/mods/nuit/fabric/NuitClientFabric.java
@@ -26,7 +26,7 @@ public class NuitClientFabric implements ClientModInitializer {
         SkyboxType.registerAll(skyboxType -> Registry.register(REGISTRY, skyboxType.getName(), skyboxType));
         ResourceLoader.get(PackType.CLIENT_RESOURCES).registerReloadListener(Identifier.fromNamespaceAndPath(NuitClient.MOD_ID, "skybox_reader"), NuitClient.skyboxResourceListener());
         ClientTickEvents.END_LEVEL_TICK.register(client -> SkyboxManager.getInstance().tick(client));
-        ClientTickEvents.END_CLIENT_TICK.register(client -> NuitClient.config().getKeyBinding().tick(client));
+        ClientTickEvents.END_CLIENT_TICK.register(NuitClient::tick);
         SkyboxDebugScreen screen = new SkyboxDebugScreen(Component.nullToEmpty("Skybox Debug Screen"));
         HudElementRegistry.addLast(Identifier.fromNamespaceAndPath(NuitClient.MOD_ID, "skybox_debug_hud"), (drawContext, tickCounter) -> screen.renderHud(drawContext));
         KeyMappingHelper.registerKeyMapping(NuitClient.config().getKeyBinding().toggleNuit);

--- a/neoforge/src/main/java/me/flashyreese/mods/nuit/neoforge/NuitNeoForge.java
+++ b/neoforge/src/main/java/me/flashyreese/mods/nuit/neoforge/NuitNeoForge.java
@@ -47,7 +47,7 @@ public final class NuitNeoForge {
 
     @SubscribeEvent
     public void registerClientTick(ClientTickEvent.Post event) {
-        NuitClient.config().getKeyBinding().tick(Minecraft.getInstance());
+        NuitClient.tick(Minecraft.getInstance());
     }
 
     @SubscribeEvent

--- a/testpacks/SkyboxSound/assets/nuit/sky/cave_sound.json
+++ b/testpacks/SkyboxSound/assets/nuit/sky/cave_sound.json
@@ -1,0 +1,31 @@
+  {
+    "schemaVersion": 1,
+    "type": "overworld",
+    "properties": {
+      "clock": "game_time",
+      "fade": {
+        "duration": 200,
+        "keyFrames": {
+          "0": 0.0,
+          "20": 1.0,
+          "80": 1.0,
+          "100": 0.0
+        }
+      },
+      "transitionInDuration": 1,
+      "transitionOutDuration": 20,
+      "sound": {
+        "file": "minecraft:sounds/ambient/cave/cave1.ogg",
+        "clipToFade": true,
+        "loop": true,
+        "delay": 20
+      }
+    },
+    "conditions": {
+      "dimensions": {
+        "entries": [
+          "minecraft:overworld"
+        ]
+      }
+    }
+  }

--- a/testpacks/SkyboxSound/pack.mcmeta
+++ b/testpacks/SkyboxSound/pack.mcmeta
@@ -1,0 +1,7 @@
+{
+  "pack": {
+    "description": "Skybox Sound Test Pack",
+    "min_format": 88,
+    "max_format": 88
+  }
+}


### PR DESCRIPTION
Resource packs can now add sounds through `properties.sound`, using the skybox’s existing conditions, fades, and clock.

Sounds can loop, fade in and out, or play after a delay. `volumeMode` provides six modes that follow fade alpha, condition alpha, or both, either scaling the volume or playing at full volume while active. The default follows both alphas. Condition fades use `transitionInDuration` and `transitionOutDuration`, allowing audio to transition smoothly when conditions change. Files use Ogg Vorbis and don’t need an entry in `sounds.json`.

Players control the volume through Minecraft’s Ambient/Environment and Master Volume sliders. Reloading resources, disabling Nuit, leaving the world, or changing dimensions stops playback.

Closes #95.